### PR TITLE
Fixed Minecraft version string matching

### DIFF
--- a/src/main/java/com/dynious/versionchecker/helper/MatchHelper.java
+++ b/src/main/java/com/dynious/versionchecker/helper/MatchHelper.java
@@ -4,6 +4,12 @@ public class MatchHelper
 {
     public static boolean doStringsMatch(String first, String second)
     {
+        if (first.startsWith("Minecraft "))
+            first = first.substring("Minecraft ".length());
+
+        if (second.startsWith("Minecraft "))
+            second = second.substring("Minecraft ".length());
+
         if (first.equals(second))
             return true;
 


### PR DESCRIPTION
- The "Minecraft " prefix must be stripped from Loader.getMCVersionString() before matching
- This fixes Version Checker being incompatible with its own version json :)
