### PR TITLE
Fixed version replacement in downloaded filenames using regex incorrectly

### DIFF
--- a/src/main/java/com/dynious/versionchecker/helper/WebHelper.java
+++ b/src/main/java/com/dynious/versionchecker/helper/WebHelper.java
@@ -55,7 +55,7 @@ public class WebHelper
     public static boolean downloadUpdate(Update update)
     {
         ModContainer mod = ModHelper.getModContainer(update.MOD_ID);
-        if (mod != null)
+        if (mod != null && mod.getSource() != null && mod.getSource().isFile())
         {
             String fileName = "";
             if (update.newFileName != null && !update.newFileName.isEmpty())
@@ -65,7 +65,7 @@ public class WebHelper
             else
             {
                 fileName = mod.getSource().getAbsolutePath();
-                String newFileName = fileName.replaceAll(update.oldVersion, update.newVersion);
+                String newFileName = fileName.replace(update.oldVersion, update.newVersion);
                 if (fileName.equalsIgnoreCase(newFileName))
                 {
                     int i = newFileName.lastIndexOf(".");


### PR DESCRIPTION
- replaceAll() uses regex, which could easily cause undesired behavior (1.1 matching 1a1, for example); replace() does the same thing as replaceAll(), but doesn't use regex
- Also added some protection against trying to update mods that are loaded from a directory (only happens in a dev environment, afaik)
