### PR TITLE
Port to 1.8.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,15 @@
 /out/
 /run/
 
+# Eclipse #
 /mappings/
+*.classpath
+.project
+*.prefs
+*.launch
+
+# Minecraft #
+/bin/
+/mods/
+/logs/
+/config/

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,13 @@ buildscript {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.2.3"
+version = "1.2.6"
 group= "com.dynious.versionchecker" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "VersionChecker"
 
 minecraft {
-	version = "1.8.8-11.14.4.1576-1.8.8"
+	version = "1.8.9-11.15.1.1722"
+	runDir="run"
 	
 	replaceIn "lib/Reference.java"
     replace "@VERSION@", project.version
@@ -32,7 +33,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20151122"
+    mappings = "stable_20"
 }
 
 dependencies {

--- a/src/main/java/com/dynious/versionchecker/checker/NEMChecker.java
+++ b/src/main/java/com/dynious/versionchecker/checker/NEMChecker.java
@@ -27,7 +27,8 @@ public class NEMChecker implements Runnable
         return Loader.MC_VERSION;
     }
 
-    @Override
+    @SuppressWarnings("resource")
+	@Override
     public void run()
     {
         InputStream inputStream = null;

--- a/src/main/java/com/dynious/versionchecker/client/gui/GuiScroll.java
+++ b/src/main/java/com/dynious/versionchecker/client/gui/GuiScroll.java
@@ -258,11 +258,11 @@ public abstract class GuiScroll
             this.client.renderEngine.bindTexture(Gui.optionsBackground);
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             float var17 = 32.0F;
-            worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-            worldr.func_181662_b((double) this.left, (double) this.bottom, 0.0D).func_181673_a( (double) ((float) this.left / var17), (double) ((float) (this.bottom + (int) this.scrollDistance) / var17) ).func_181669_b(0x20, 0x20, 0x20,  255).func_181675_d();
-            worldr.func_181662_b((double) this.right, (double) this.bottom, 0.0D).func_181673_a((double) ((float) this.right / var17), (double) ((float) (this.bottom + (int) this.scrollDistance) / var17)).func_181669_b(0x20, 0x20, 0x20,  255).func_181675_d();
-            worldr.func_181662_b((double) this.right, (double) this.top, 0.0D).func_181673_a((double) ((float) this.right / var17), (double) ((float) (this.top + (int) this.scrollDistance) / var17)).func_181669_b(0x20, 0x20, 0x20,  255).func_181675_d();
-            worldr.func_181662_b((double) this.left, (double) this.top, 0.0D).func_181673_a((double) ((float) this.left / var17), (double) ((float) (this.top + (int) this.scrollDistance) / var17)).func_181669_b(0x20, 0x20, 0x20,  255).func_181675_d();
+            worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+            worldr.pos((double) this.left, (double) this.bottom, 0.0D).tex( (double) ((float) this.left / var17), (double) ((float) (this.bottom + (int) this.scrollDistance) / var17) ).color(0x20, 0x20, 0x20,  255).endVertex();
+            worldr.pos((double) this.right, (double) this.bottom, 0.0D).tex((double) ((float) this.right / var17), (double) ((float) (this.bottom + (int) this.scrollDistance) / var17)).color(0x20, 0x20, 0x20,  255).endVertex();
+            worldr.pos((double) this.right, (double) this.top, 0.0D).tex((double) ((float) this.right / var17), (double) ((float) (this.top + (int) this.scrollDistance) / var17)).color(0x20, 0x20, 0x20,  255).endVertex();
+            worldr.pos((double) this.left, (double) this.top, 0.0D).tex((double) ((float) this.left / var17), (double) ((float) (this.top + (int) this.scrollDistance) / var17)).color(0x20, 0x20, 0x20,  255).endVertex();
             tess.draw();
         }
         //        boxRight = this.listWidth / 2 - 92 - 16;
@@ -284,17 +284,17 @@ public abstract class GuiScroll
                 {
                     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                     GL11.glDisable(GL11.GL_TEXTURE_2D);
-                    worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
+                    worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
 
-                    worldr.func_181662_b((double) boxLeft, (double) (drawY + curSlotHeight + 2), 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) boxRight, (double) (drawY + curSlotHeight + 2), 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) boxRight, (double) (drawY - 2), 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) boxLeft, (double) (drawY - 2), 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
+                    worldr.pos((double) boxLeft, (double) (drawY + curSlotHeight + 2), 0.0D).tex( 0.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) boxRight, (double) (drawY + curSlotHeight + 2), 0.0D).tex( 1.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) boxRight, (double) (drawY - 2), 0.0D).tex( 1.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) boxLeft, (double) (drawY - 2), 0.0D).tex( 0.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
 
-                    worldr.func_181662_b((double) (boxLeft + 1), (double) (drawY + curSlotHeight + 1), 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) (boxRight - 1), (double) (drawY + curSlotHeight + 1), 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) (boxRight - 1), (double) (drawY - 1), 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-                    worldr.func_181662_b((double) (boxLeft + 1), (double) (drawY - 1), 0.0D).func_181673_a(0.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
+                    worldr.pos((double) (boxLeft + 1), (double) (drawY + curSlotHeight + 1), 0.0D).tex( 0.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) (boxRight - 1), (double) (drawY + curSlotHeight + 1), 0.0D).tex( 1.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) (boxRight - 1), (double) (drawY - 1), 0.0D).tex( 1.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
+                    worldr.pos((double) (boxLeft + 1), (double) (drawY - 1), 0.0D).tex(0.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
                     
                     tess.draw();
                     GL11.glEnable(GL11.GL_TEXTURE_2D);
@@ -317,18 +317,18 @@ public abstract class GuiScroll
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         GL11.glShadeModel(GL11.GL_SMOOTH);
         GL11.glDisable(GL11.GL_TEXTURE_2D);
-        worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-        worldr.func_181662_b((double) this.left, (double) (this.top + fadeGradientHeight), 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-        worldr.func_181662_b((double) this.right, (double) (this.top + fadeGradientHeight), 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-        worldr.func_181662_b((double) this.right, (double) this.top, 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0,0,0,255).func_181675_d();
-        worldr.func_181662_b((double) this.left, (double) this.top, 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0,0,0,255).func_181675_d();
+        worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldr.pos((double) this.left, (double) (this.top + fadeGradientHeight), 0.0D).tex( 0.0D, 1.0D).color(0,0,0,255).endVertex();
+        worldr.pos((double) this.right, (double) (this.top + fadeGradientHeight), 0.0D).tex( 1.0D, 1.0D).color(0,0,0,255).endVertex();
+        worldr.pos((double) this.right, (double) this.top, 0.0D).tex( 1.0D, 0.0D).color(0,0,0,255).endVertex();
+        worldr.pos((double) this.left, (double) this.top, 0.0D).tex( 0.0D, 0.0D).color(0,0,0,255).endVertex();
         tess.draw();
-        worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
+        worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
         
-        worldr.func_181662_b((double) this.left, (double) this.bottom, 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-        worldr.func_181662_b((double) this.right, (double) this.bottom, 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-        worldr.func_181662_b((double) this.right, (double) (this.bottom - fadeGradientHeight), 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0,0,0,0).func_181675_d();
-        worldr.func_181662_b((double) this.left, (double) (this.bottom - fadeGradientHeight), 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0,0,0,0).func_181675_d();
+        worldr.pos((double) this.left, (double) this.bottom, 0.0D).tex( 0.0D, 1.0D).color(0,0,0,255).endVertex();
+        worldr.pos((double) this.right, (double) this.bottom, 0.0D).tex( 1.0D, 1.0D).color(0,0,0,255).endVertex();
+        worldr.pos((double) this.right, (double) (this.bottom - fadeGradientHeight), 0.0D).tex( 1.0D, 0.0D).color(0,0,0,0).endVertex();
+        worldr.pos((double) this.left, (double) (this.bottom - fadeGradientHeight), 0.0D).tex( 0.0D, 0.0D).color(0,0,0,0).endVertex();
         tess.draw();
 
         float maxScrollDistance = getMaxScrollDistance();
@@ -338,23 +338,23 @@ public abstract class GuiScroll
             int scrollBarTop = (int) (this.scrollDistance * (getVisibleHeight() - scrollBarHeight) / maxScrollDistance + this.top);
             scrollBarTop = Math.max(top, scrollBarTop);
 
-            worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-            worldr.func_181662_b((double) scrollBarXStart, (double) this.bottom, 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXEnd, (double) this.bottom, 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0,0,0,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXEnd, (double) this.top, 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0,0,0,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXStart, (double) this.top, 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0,0,0,255).func_181675_d();
+            worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+            worldr.pos((double) scrollBarXStart, (double) this.bottom, 0.0D).tex( 0.0D, 1.0D).color(0,0,0,255).endVertex();
+            worldr.pos((double) scrollBarXEnd, (double) this.bottom, 0.0D).tex( 1.0D, 1.0D).color(0,0,0,255).endVertex();
+            worldr.pos((double) scrollBarXEnd, (double) this.top, 0.0D).tex( 1.0D, 0.0D).color(0,0,0,255).endVertex();
+            worldr.pos((double) scrollBarXStart, (double) this.top, 0.0D).tex( 0.0D, 0.0D).color(0,0,0,255).endVertex();
             tess.draw();
-            worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-            worldr.func_181662_b((double) scrollBarXStart, (double) (scrollBarTop + scrollBarHeight), 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXEnd, (double) (scrollBarTop + scrollBarHeight), 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXEnd, (double) scrollBarTop, 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXStart, (double) scrollBarTop, 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0x80,0x80,0x80,255).func_181675_d();
+            worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+            worldr.pos((double) scrollBarXStart, (double) (scrollBarTop + scrollBarHeight), 0.0D).tex( 0.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+            worldr.pos((double) scrollBarXEnd, (double) (scrollBarTop + scrollBarHeight), 0.0D).tex( 1.0D, 1.0D).color(0x80,0x80,0x80,255).endVertex();
+            worldr.pos((double) scrollBarXEnd, (double) scrollBarTop, 0.0D).tex( 1.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
+            worldr.pos((double) scrollBarXStart, (double) scrollBarTop, 0.0D).tex( 0.0D, 0.0D).color(0x80,0x80,0x80,255).endVertex();
             tess.draw();
-            worldr.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-            worldr.func_181662_b((double) scrollBarXStart, (double) (scrollBarTop + scrollBarHeight - 1), 0.0D).func_181673_a( 0.0D, 1.0D).func_181669_b(0xC0,0xC0,0xC0,255).func_181675_d();
-            worldr.func_181662_b((double) (scrollBarXEnd - 1), (double) (scrollBarTop + scrollBarHeight - 1), 0.0D).func_181673_a( 1.0D, 1.0D).func_181669_b(0xC0,0xC0,0xC0,255).func_181675_d();
-            worldr.func_181662_b((double) (scrollBarXEnd - 1), (double) scrollBarTop, 0.0D).func_181673_a( 1.0D, 0.0D).func_181669_b(0xC0,0xC0,0xC0,255).func_181675_d();
-            worldr.func_181662_b((double) scrollBarXStart, (double) scrollBarTop, 0.0D).func_181673_a( 0.0D, 0.0D).func_181669_b(0xC0,0xC0,0xC0,255).func_181675_d();
+            worldr.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+            worldr.pos((double) scrollBarXStart, (double) (scrollBarTop + scrollBarHeight - 1), 0.0D).tex( 0.0D, 1.0D).color(0xC0,0xC0,0xC0,255).endVertex();
+            worldr.pos((double) (scrollBarXEnd - 1), (double) (scrollBarTop + scrollBarHeight - 1), 0.0D).tex( 1.0D, 1.0D).color(0xC0,0xC0,0xC0,255).endVertex();
+            worldr.pos((double) (scrollBarXEnd - 1), (double) scrollBarTop, 0.0D).tex( 1.0D, 0.0D).color(0xC0,0xC0,0xC0,255).endVertex();
+            worldr.pos((double) scrollBarXStart, (double) scrollBarTop, 0.0D).tex( 0.0D, 0.0D).color(0xC0,0xC0,0xC0,255).endVertex();
             tess.draw();
         }
 
@@ -390,11 +390,11 @@ public abstract class GuiScroll
         GL11.glShadeModel(GL11.GL_SMOOTH);
         Tessellator tessellator = Tessellator.getInstance();
         WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-        worldrenderer.func_181668_a(7, DefaultVertexFormats.field_181709_i);
-        worldrenderer.func_181662_b((double)par3, (double)par2, 0.0D).func_181666_a(f1, f2, f3, f).func_181675_d();
-        worldrenderer.func_181662_b((double)par1, (double)par2, 0.0D).func_181666_a(f1, f2, f3, f).func_181675_d();
-        worldrenderer.func_181662_b((double)par1, (double)par4, 0.0D).func_181666_a(f5, f6, f7, f4).func_181675_d();
-        worldrenderer.func_181662_b((double)par3, (double)par4, 0.0D).func_181666_a(f5, f6, f7, f4).func_181675_d();
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos((double)par3, (double)par2, 0.0D).color(f1, f2, f3, f).endVertex();
+        worldrenderer.pos((double)par1, (double)par2, 0.0D).color(f1, f2, f3, f).endVertex();
+        worldrenderer.pos((double)par1, (double)par4, 0.0D).color(f5, f6, f7, f4).endVertex();
+        worldrenderer.pos((double)par3, (double)par4, 0.0D).color(f5, f6, f7, f4).endVertex();
         tessellator.draw();
         GL11.glShadeModel(GL11.GL_FLAT);
         GL11.glDisable(GL11.GL_BLEND);

--- a/version.json
+++ b/version.json
@@ -30,6 +30,16 @@
 			"updateURL":"http://minecraft.curseforge.com/projects/version-checker/files/2269961/download",
 			"isDirectLink":"true",
 			"newFileName":""
+		},
+        {
+			"mcVersion":"Minecraft 1.8.9",
+			"modVersion":"1.2.6",
+			"changeLog": [
+                "Port to 1.8.9"
+			],
+			"updateURL":"http://minecraft.curseforge.com/projects/version-checker/files/PLEASECHANGELATER",
+			"isDirectLink":"true",
+			"newFileName":""
 		}
 	]
 }


### PR DESCRIPTION
Only a bit needed to be changed.
But I needed to update the .gitignore to not upload much files (Eclipse, Minecraft Run Test, etc.).
Everything works so far. The only thing I noticed is, that when you click on an existing update, the whole window gets bright, not only the frame. The whole window is the area around the update, that is shown.
I will try to fix the NBTTag-Bug #81 within the next few days... Maybe I can manage to do that...